### PR TITLE
Update Go CI workflow for Wails builds

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-# This workflow will build a golang project
+# This workflow builds and tests the Go project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
@@ -10,19 +10,44 @@ on:
     branches: [ "main" ]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.20'
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \ 
+            build-essential \ 
+            libgtk-3-dev \ 
+            libwebkit2gtk-4.0-dev \ 
+            libayatana-appindicator3-dev \ 
+            patchelf
 
-    - name: Build
-      run: go build -v ./...
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
 
-    - name: Test
-      run: go test -v ./...
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Go build
+        run: go build -v ./...
+
+      - name: Go test
+        run: go test -v ./...


### PR DESCRIPTION
## Summary
- install the Linux packages Wails needs on ubuntu-latest runners
- add Node 18 setup plus npm install/build steps for the frontend bundle
- switch the Go setup action to v5 and target Go 1.21 before building and testing

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6be0350c8832f85965cbebd7fc26b