### PR TITLE
Harden download client and align installer messaging

### DIFF
--- a/internal/kumi/install/custom.go
+++ b/internal/kumi/install/custom.go
@@ -12,6 +12,8 @@ import (
 func CustomMods(deps Dependencies, modsDir, zipURL string) (*ktypes.ActionResult, error) {
 	result := ktypes.NewResult()
 
+	modsDir = strings.Trim(modsDir, "\"")
+
 	if strings.TrimSpace(modsDir) == "" {
 		result.Error("mods directory is required")
 		result.Success = false

--- a/internal/kumi/install/generic.go
+++ b/internal/kumi/install/generic.go
@@ -33,6 +33,7 @@ func InstanceWithOptionalZip(deps Dependencies, label string, candidates []strin
 
 	if strings.TrimSpace(zipURL) == "" {
 		result.Warning(warning)
+		result.Info(fmt.Sprintf("%s install complete.", label))
 		result.Success = true
 		return result, nil
 	}
@@ -44,6 +45,7 @@ func InstanceWithOptionalZip(deps Dependencies, label string, candidates []strin
 	}
 
 	result.Info(fmt.Sprintf("Installed %s instance to %s", label, target))
+	result.Info(fmt.Sprintf("%s install complete.", label))
 	result.Success = true
 	return result, nil
 }

--- a/internal/kumi/install/manual.go
+++ b/internal/kumi/install/manual.go
@@ -11,6 +11,8 @@ import (
 func Manual(deps Dependencies, target, zipURL string) (*ktypes.ActionResult, error) {
 	result := ktypes.NewResult()
 
+	target = strings.Trim(target, "\"")
+
 	var err error
 	if strings.TrimSpace(target) == "" {
 		target, err = os.Getwd()

--- a/internal/kumi/net.go
+++ b/internal/kumi/net.go
@@ -56,6 +56,10 @@ func (s *Service) downloadFile(url string, file *os.File) error {
 	}
 	req.Header.Set("User-Agent", userAgent)
 
+	if s.ctx != nil {
+		req = req.WithContext(s.ctx)
+	}
+
 	resp, err := s.client.Do(req)
 	if err != nil {
 		return err

--- a/internal/kumi/service.go
+++ b/internal/kumi/service.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 
+	"crypto/tls"
+
 	"polyforge/internal/kumi/install"
 )
 
@@ -41,7 +43,8 @@ type Service struct {
 }
 
 func NewService() *Service {
-	return &Service{client: &http.Client{}}
+	transport := &http.Transport{TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
+	return &Service{client: &http.Client{Transport: transport}}
 }
 
 func (s *Service) SetContext(ctx context.Context) {


### PR DESCRIPTION
## Summary
- enforce TLS 1.2+ for backend downloads and respect cancellation when fetching installer archives
- normalize user-supplied paths and mirror the PowerShell script's completion messaging for optional zip installs

## Testing
- go test ./internal/...


------
https://chatgpt.com/codex/tasks/task_e_68d7c57264a4832fac418a6abd39ef05