### PR TITLE
Add vite-plugin-pug dev dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,8 @@
       "devDependencies": {
         "sass": "^1.69.5",
         "typescript": "^5.3.3",
-        "vite": "^5.1.0"
+        "vite": "^5.1.0",
+        "vite-plugin-pug": "^0.4.1"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1990,6 +1991,17 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-pug": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-pug/-/vite-plugin-pug-0.4.1.tgz",
+      "integrity": "sha512-2M4qNpIgUV+zA63w566jyp3LpaIuSBMfghOzue7PYnFTms48Ux78Bp/ccRSaGRbFW9BkTxdqgi5h7xvBN7YruQ==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "picocolors": "~1",
+        "pug": "^3.0.3"
       }
     },
     "node_modules/void-elements": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "pug-runtime": "^3.0.1"
   },
   "devDependencies": {
+    "vite-plugin-pug": "^0.4.1",
     "sass": "^1.69.5",
     "typescript": "^5.3.3",
     "vite": "^5.1.0"


### PR DESCRIPTION
## Summary
- add the vite-plugin-pug package to the frontend dev dependencies
- update the lockfile to include the new plugin

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7d51e60d0832f836bf3496a4182a3