### PR TITLE
Fix Wails Windows bindings target architecture

### DIFF
--- a/wails.json
+++ b/wails.json
@@ -19,11 +19,11 @@
     "devServerURL": "http://127.0.0.1:5173",
     "compiler": "esbuild",
     "platform": {
-      "linux": {
+      "windows": {
         "arch": ["amd64"]
       },
-      "windows": {
-        "arch": ["x64"]
+      "linux": {
+        "arch": ["amd64"]
       }
     }
   }


### PR DESCRIPTION
## Summary
- set the Windows build target to the Go `amd64` architecture in `wails.json`
- reorder the platform list so local Windows development no longer tries to execute a Linux bindings generator

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7e58444ec832f922edbe1d92e6c97