### PR TITLE
Add Windows build helper script and clarify binding workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,17 @@ Keehan's Universal Modpack Installer (KUMI) rebuilt as a [Wails](https://wails.i
      pwsh scripts/wails-dev.ps1
      ```
 
+4. To produce a release build on Windows use the companion helper, which performs the same environment normalisation before
+   delegating to `wails build`:
+
+   ```powershell
+   pwsh scripts/wails-build.ps1
+   ```
+
+### Troubleshooting Windows binding errors
+
+If Wails reports `This version of %1 is not compatible with the version of Windows you're running` when generating bindings,
+the cached helper at `%TEMP%\wailsbindings.exe` is usually a stale 32-bit binary. The PowerShell helpers above delete the cache
+automatically, but you can also remove the file manually and retry the command if you need to invoke `wails` directly.
+
 The wizard guides users through accepting the licence, selecting an action, choosing the modpack and launcher, and finally streams structured logs as the backend performs the installation. Utilities for Modrinth profile cloning, executable search, and launcher profile generation are exposed through the Go service for future UI integration.

--- a/scripts/wails-build.ps1
+++ b/scripts/wails-build.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$ArgsToForward
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Ensure-Command {
+    param(
+        [string]$CommandName
+    )
+
+    if (-not (Get-Command $CommandName -ErrorAction SilentlyContinue)) {
+        throw "Required command '$CommandName' was not found in PATH."
+    }
+}
+
+Ensure-Command -CommandName 'go'
+Ensure-Command -CommandName 'wails'
+
+$expectedGoOS = 'windows'
+$expectedGoArch = 'amd64'
+$currentGoOS = (& go env GOOS).Trim()
+$currentGoArch = (& go env GOARCH).Trim()
+
+if ($currentGoOS -ne $expectedGoOS -or $currentGoArch -ne $expectedGoArch) {
+    Write-Host "Normalising Go toolchain environment for Wails (GOOS=$expectedGoOS, GOARCH=$expectedGoArch)." -ForegroundColor Yellow
+    $env:GOOS = $expectedGoOS
+    $env:GOARCH = $expectedGoArch
+} else {
+    Remove-Item Env:GOOS -ErrorAction SilentlyContinue
+    Remove-Item Env:GOARCH -ErrorAction SilentlyContinue
+}
+
+$tempBindings = Join-Path ([System.IO.Path]::GetTempPath()) 'wailsbindings.exe'
+if (Test-Path $tempBindings) {
+    try {
+        Remove-Item $tempBindings -ErrorAction Stop
+        Write-Host "Removed stale binding helper at $tempBindings" -ForegroundColor DarkGray
+    } catch {
+        Write-Warning "Unable to remove existing binding helper ($tempBindings): $_"
+    }
+}
+
+Write-Host "Executing: wails build $ArgsToForward" -ForegroundColor Cyan
+& wails build @ArgsToForward


### PR DESCRIPTION
## Summary
- add a PowerShell helper that normalises the Go environment before calling `wails build`
- document the Windows build helper and outline how to clear stale `wailsbindings.exe` caches when errors appear

## Testing
- not run (docs and scripting changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d7f16826dc832f835d2e12be28fbef