### PR TITLE
Update Go toolchain to 1.24.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module polyforge
 
-go 1.22.0
+go 1.24
 
-toolchain go1.24.3
+toolchain go1.24.7
 
 require (
 	github.com/glebarez/sqlite v1.11.0


### PR DESCRIPTION
## Summary
- bump the Go language version directive to 1.24 and align the toolchain with Go 1.24.7

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d80fe41354832fb50bd469d334e7d8