### PR TITLE
Use Windows PowerShell for Wails prebuild hook

### DIFF
--- a/wails.json
+++ b/wails.json
@@ -28,6 +28,6 @@
     }
   },
   "preBuildHooks": {
-    "windows/amd64": "pwsh -NoProfile -ExecutionPolicy Bypass -File scripts\\cleanup-wailsbindings.ps1"
+    "windows/amd64": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts\\cleanup-wailsbindings.ps1"
   }
 }


### PR DESCRIPTION
## Summary
- switch the Windows pre-build hook to call Windows PowerShell so it works when PowerShell Core is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d934fe1d88832fab3407eb1f838f09