### PR TITLE
Fix Wails Windows prebuild hook path

### DIFF
--- a/wails.json
+++ b/wails.json
@@ -28,6 +28,6 @@
     }
   },
   "preBuildHooks": {
-    "windows/amd64": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts\\cleanup-wailsbindings.ps1"
+    "windows/amd64": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/cleanup-wailsbindings.ps1"
   }
 }


### PR DESCRIPTION
## Summary
- fix the Windows prebuild hook path so PowerShell resolves the cleanup script correctly

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d935de7744832fac5dcca3f68d7b27