### PR TITLE
Fix PowerShell error message formatting

### DIFF
--- a/scripts/cleanup-wailsbindings.ps1
+++ b/scripts/cleanup-wailsbindings.ps1
@@ -10,7 +10,7 @@ if (Test-Path $bindingPath) {
         Write-Host "Removed stale Wails binding helper at $bindingPath" -ForegroundColor DarkGray
     }
     catch {
-        Write-Error "Failed to remove cached wailsbindings helper at $bindingPath: $_"
+        Write-Error "Failed to remove cached wailsbindings helper at ${bindingPath}: $_"
         exit 1
     }
 } else {


### PR DESCRIPTION
## Summary
- wrap the interpolated variable in braces so PowerShell can parse the error message string

## Testing
- not run (PowerShell is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d93797443c832fbc3fdf148bf41332