### PR TITLE
Fix Wails prebuild hook path

### DIFF
--- a/wails.json
+++ b/wails.json
@@ -28,6 +28,6 @@
     }
   },
   "preBuildHooks": {
-    "windows/amd64": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/cleanup-wailsbindings.ps1"
+    "windows/amd64": "powershell -NoProfile -ExecutionPolicy Bypass -File \"{{.ProjectDir}}\\scripts\\cleanup-wailsbindings.ps1\""
   }
 }


### PR DESCRIPTION
## Summary
- ensure the Windows prebuild hook runs from the project directory by invoking the cleanup script via its absolute path template

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d938bea690832f9fd89a4a020cdfba