### PR TITLE
Fix Windows pre-build hook path quoting

### DIFF
--- a/wails.json
+++ b/wails.json
@@ -28,6 +28,6 @@
     }
   },
   "preBuildHooks": {
-    "windows/amd64": "powershell -NoProfile -ExecutionPolicy Bypass -File \"{{.ProjectDir}}\\scripts\\cleanup-wailsbindings.ps1\""
+    "windows/amd64": "powershell -NoProfile -ExecutionPolicy Bypass -File \"{{.ProjectDir}}/scripts/cleanup-wailsbindings.ps1\""
   }
 }


### PR DESCRIPTION
## Summary
- correct the Windows pre-build hook command so PowerShell resolves the cleanup script path properly

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d939ae2ad8832f9a6ebf730a5f4924