### PR TITLE
Fix Windows prebuild hook path

### DIFF
--- a/wails.json
+++ b/wails.json
@@ -28,6 +28,6 @@
     }
   },
   "preBuildHooks": {
-    "windows/amd64": "powershell -NoProfile -ExecutionPolicy Bypass -File \"{{.ProjectDir}}/scripts/cleanup-wailsbindings.ps1\""
+    "windows/amd64": "powershell -NoProfile -ExecutionPolicy Bypass -File ..\\..\\scripts\\cleanup-wailsbindings.ps1"
   }
 }


### PR DESCRIPTION
## Summary
- point the Windows pre-build hook to the cleanup script using a relative path that resolves from the build/bin directory

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d93b0fb748832f81605cc6e19fc06b