### PR TITLE
Ensure loading overlay hides when not busy

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -93,6 +93,10 @@ body {
   pointer-events: none;
 }
 
+.app-shell__overlay[hidden] {
+  display: none !important;
+}
+
 .overlay__spinner {
   width: 42px;
   height: 42px;


### PR DESCRIPTION
## Summary
- ensure the app shell overlay respects the `hidden` attribute so the loading spinner disappears once work completes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e9fd45dd0c832f8d5b27c95db1b1f5